### PR TITLE
Force preview scene to match project resolution

### DIFF
--- a/addons/Previewer_2D_3D/Previewer2D3D.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D.gd
@@ -46,6 +46,9 @@ func _ready():
 	await get_tree().process_frame
 	#Set starting size
 	size.x = 640
+	#Update control nodes to fit project resolution
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	subviewport_texture.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	pass # Replace with function body.
 
 


### PR DESCRIPTION
This PR aims to fix [low res previews](https://github.com/Meta-Ben/Previewer_2D_3D/issues/1) by forcing the control nodes to be resized when the plugin is initialized.