### PR TITLE
Hover to swap between 2D and 3D viewports

### DIFF
--- a/addons/Previewer_2D_3D/Previewer2D3D.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D.gd
@@ -4,202 +4,44 @@ extends Control
 
 var editor_plugin : EditorPlugin
 
-#UI
-@onready var container = $Container
-
-#Option UI
-@onready var optionsContainer = $Container/OptionsContainer
-@onready var titleLabel = $Container/OptionsContainer/Title
-@onready var positionMenuButtons = $Container/OptionsContainer/HBoxContainer/MenuButton
-
 #Preview UI
-@onready var previewContainer = $Container/PreviewContainer
-@onready var subviewport_2D = $"Container/PreviewContainer/2D_Viewport"
-@onready var subviewport_3D = $"Container/PreviewContainer/3D_Viewport"
-@onready var current_subviewport = $Container/PreviewContainer/Current_Viewport
-@onready var subviewport_texture = $Container/PreviewContainer/TextureRect
-
-
-#User Input Variables
-var initial_mouse_pos = -1
-
-#Moving variables
-var is_moving = false
-var inital_transform : Transform2D
-var initial_camera_3D : Camera3D
-var old_rotation 
-var moving_factor = 0.05
-
-#Rotating variables
-var is_rotating = false
-var rotating_factor = 0.001
-
-#Zoom variables
-var zoom_factor = 1.1
-
-#Settings variables
-var mode: Previewer2D3D_Enums.PreviewMode = Previewer2D3D_Enums.PreviewMode.PREVIEW_2D
-
+@onready var texture_rect : TextureRect = $TextureRect
+@onready var current_subviewport : SubViewport = $Current_SubViewport
+@onready var subviewport_2D : SubViewport = $SubViewport_2D
+@onready var subviewport_3D : SubViewport = $SubViewport_3D
+#Values
+var current_preview_mode : int
+var godot_split_size : float = 4.0 #Pixel width of Godot's split container handlebar (prevents 2D viewer from pushing 3D viewer back)
 
 # Called when the node enters the scene tree for the first time.
-func _ready():
-	await get_tree().process_frame
-	#Set starting size
-	size.x = 640
-	#Update control nodes to fit project resolution
-	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	subviewport_texture.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	if not visible:
-		return
-		
-
-	_setup_viewports()
-	
-	#Reset the editor3D when the plugin is disabled view to avoid trouble
-	#Since we do modification on the real viewport
-	if EditorInterface.is_plugin_enabled("2D3D_visualization") == false:
-		_reset_3D_view_default_settings()
-		
+func _ready() -> void:
 	pass
 
+func _process(delta: float) -> void:
+	#Force viewport size update
+	match current_preview_mode:
+		Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
+			subviewport_2D.size = size
+		Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
+			subviewport_3D.size = size
 
-
-func _setup_viewports():
-	if not visible:
-		return
-		
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
-		_manage_2D_preview()
-		pass
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
-		_manage_3D_preview()
-		pass
-	
-	#UPDATE_ALWAYS allow us to modify the viewport even if the view it refer is no more visible
+func switch_preview(preview_mode : int, preview_size : Vector2) -> void:
+	current_preview_mode = preview_mode
+	match current_preview_mode:
+		Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
+			current_subviewport = subviewport_2D
+			subviewport_2D.world_2d = EditorInterface.get_editor_viewport_2d().world_2d
+			subviewport_2D.global_canvas_transform = EditorInterface.get_editor_viewport_2d().global_canvas_transform
+			subviewport_2D.size = EditorInterface.get_editor_viewport_2d().size
+			get_parent().split_offset = (preview_size.x)
+			#Enable 3D subviewport stretch
+			EditorInterface.get_editor_viewport_3d().get_parent().stretch = true
+		Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
+			current_subviewport = subviewport_3D
+			subviewport_3D = EditorInterface.get_editor_viewport_3d()
+			#subviewport_3D.size = EditorInterface.get_editor_viewport_3d().size
+			get_parent().split_offset = ((get_parent_control().size.x - preview_size.x) - godot_split_size)
+			#Disable 3D subviewport stretch
+			EditorInterface.get_editor_viewport_3d().get_parent().stretch = false
 	current_subviewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
-	current_subviewport.size.y = size.y
-	current_subviewport.size.x = size.x
-	subviewport_texture.texture = current_subviewport.get_texture()
-	subviewport_texture.size.x = size.x
-	
-	#Force position to 0, 0 to avoid some trouble with resizing
-	subviewport_texture.position = Vector2(0, 0)
-
-#For 3D since the editor view port use camera we can just set the viewport as is
-func _manage_3D_preview():
-	#Hack to be able to resize the 3D viewport
-	#In fact we just access to the 3D real parent to set it stretch to true
-	_set_3D_view_plugin_settings()
-	
-	subviewport_3D = EditorInterface.get_editor_viewport_3d()
-	current_subviewport = subviewport_3D
-	pass
-
-#For 2D since the editor view port dont use camera we need to set the world and the canvas to respect the "camera" position
-func _manage_2D_preview():
-	#Reset the modification happened during the 2D preview ( due to the hack )
-	#Reput the stretch setting at normal to avoid breaking the 3D editor
-	_reset_3D_view_default_settings()
-
-	subviewport_2D.world_2d = EditorInterface.get_editor_viewport_2d().world_2d
-	subviewport_2D.global_canvas_transform = EditorInterface.get_editor_viewport_2d().global_canvas_transform
-	current_subviewport = subviewport_2D
-
-func set_2D_preview_mode():
-	mode = 0
-	if titleLabel:
-		titleLabel.text = "2D Preview"
-	pass
-	
-func set_3D_preview_mode():
-	mode = 1
-	if titleLabel:
-		titleLabel.text = "3D Preview"
-	pass
-
-func _set_3D_view_plugin_settings():
-	EditorInterface.get_editor_viewport_3d().get_parent().stretch = false
-	
-func _reset_3D_view_default_settings():
-	EditorInterface.get_editor_viewport_3d().get_parent().stretch = true
-	
-	
-func _manage_move(event):
-	var mouse_delta = initial_mouse_pos - get_global_mouse_position()
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
-		EditorInterface.get_editor_viewport_2d().global_canvas_transform.origin = inital_transform.origin - mouse_delta
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
-		var camera_3D = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-		var moving_values = Vector3(event.relative.x * moving_factor, event.relative.y * moving_factor, 0)
-		camera_3D.global_transform.origin -= camera_3D.global_transform.basis * moving_values
-		
-
-func _manage_rotation(event):
-	var mouse_delta = initial_mouse_pos - get_global_mouse_position()
-	var camera_3D = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-	var rotation_value = Vector3(mouse_delta.x , mouse_delta.y, 0).normalized()
-	camera_3D.rotate(Vector3.UP, -event.relative.x * rotating_factor)
-	camera_3D.rotate_object_local(Vector3.RIGHT, -event.relative.y * rotating_factor)
-
-func _manage_zoom_in():
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
-		current_subviewport.canvas_transform.x *= zoom_factor
-		current_subviewport.canvas_transform.y *= zoom_factor
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
-		var camera_3D = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-		camera_3D.position *= zoom_factor
-		pass
-
-func _manage_zoom_out():
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
-		current_subviewport.canvas_transform.x /= zoom_factor
-		current_subviewport.canvas_transform.y /= zoom_factor
-	if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
-		var camera_3D = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-		camera_3D.position /= zoom_factor
-		pass
-		
-func _on_preview_container_gui_input(event):
-	if event is InputEventMouseMotion:
-		if is_moving:
-			_manage_move(event)
-		if is_rotating:
-			_manage_rotation(event)
-			
-	if event is InputEventMouseButton:		
-		if event.button_index == MOUSE_BUTTON_MIDDLE:
-			if event.is_pressed():
-				initial_mouse_pos = get_global_mouse_position()
-				is_moving = true
-				if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_2D:
-					inital_transform = EditorInterface.get_editor_viewport_2d().global_canvas_transform
-				if mode == Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
-					initial_camera_3D = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-					old_rotation = initial_camera_3D.rotation_degrees
-			if event.is_released():
-				is_moving = false
-					
-				
-				
-		if event.button_index == MOUSE_BUTTON_RIGHT:
-			if event.is_pressed():
-				initial_mouse_pos = get_global_mouse_position()
-				is_rotating = true
-				#Only for 3D
-				initial_camera_3D = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-			if event.is_released():
-				is_rotating = false
-				
-				
-		if event.button_index == MOUSE_BUTTON_WHEEL_UP:
-			_manage_zoom_in()
-			pass
-		if event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
-			_manage_zoom_out()
-			pass
-	pass # Replace with function body.
+	texture_rect.texture = current_subviewport.get_texture()

--- a/addons/Previewer_2D_3D/Previewer2D3D.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D.gd
@@ -46,6 +46,9 @@ func _ready():
 	await get_tree().process_frame
 	#Set starting size
 	size.x = 640
+	#Update control nodes to fit project resolution
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	subviewport_texture.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	pass # Replace with function body.
 
 

--- a/addons/Previewer_2D_3D/Previewer2D3D.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D.gd
@@ -39,7 +39,6 @@ func switch_preview(preview_mode : int, preview_size : Vector2) -> void:
 		Previewer2D3D_Enums.PreviewMode.PREVIEW_3D:
 			current_subviewport = subviewport_3D
 			subviewport_3D = EditorInterface.get_editor_viewport_3d()
-			#subviewport_3D.size = EditorInterface.get_editor_viewport_3d().size
 			get_parent().split_offset = ((get_parent_control().size.x - preview_size.x) - godot_split_size)
 			#Disable 3D subviewport stretch
 			EditorInterface.get_editor_viewport_3d().get_parent().stretch = false

--- a/addons/Previewer_2D_3D/Previewer2D3D.tscn
+++ b/addons/Previewer_2D_3D/Previewer2D3D.tscn
@@ -1,99 +1,37 @@
-[gd_scene load_steps=7 format=3 uid="uid://cuibvk4ffcht6"]
+[gd_scene load_steps=3 format=3 uid="uid://cuibvk4ffcht6"]
 
 [ext_resource type="Script" path="res://addons/Previewer_2D_3D/Previewer2D3D.gd" id="1_4gyua"]
-[ext_resource type="Texture2D" uid="uid://bx5b5pehranab" path="res://addons/Previewer_2D_3D/Icons/option.png" id="2_nerf3"]
 
-[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_q3rui"]
-load_path = "res://.godot/imported/left.png-a60ec8a30bd45585cb988a69d945e60b.ctex"
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_vtmcs"]
 
-[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_8crud"]
-load_path = "res://.godot/imported/right.png-9cc6d7d936785b805dc429437a2f4ab7.ctex"
-
-[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_8di4p"]
-load_path = "res://.godot/imported/botom.png-80a435593c6bac454efb141a994fa9d3.ctex"
-
-[sub_resource type="ViewportTexture" id="ViewportTexture_ffsvy"]
-viewport_path = NodePath("Container/PreviewContainer/Current_Viewport")
-
-[node name="Preview" type="Control"]
+[node name="Preview" type="PanelContainer"]
 z_index = 999
-custom_minimum_size = Vector2(640, 300)
-layout_mode = 3
+clip_contents = true
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -384.0
-offset_right = -896.0
-offset_bottom = 1078.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_vtmcs")
 script = ExtResource("1_4gyua")
 metadata/_edit_vertical_guides_ = [-577.0, -313.0, -209.0]
 
-[node name="Container" type="VBoxContainer" parent="."]
-clip_contents = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="OptionsContainer" type="MarginContainer" parent="Container"]
-custom_minimum_size = Vector2(640, 0)
-layout_direction = 2
+[node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 2
+color = Color(0.298039, 0.298039, 0.298039, 1)
 
-[node name="Title" type="Label" parent="Container/OptionsContainer"]
-clip_contents = true
+[node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 2
-text = "2D Preview"
-vertical_alignment = 1
+expand_mode = 1
+stretch_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Container/OptionsContainer"]
-layout_mode = 2
-alignment = 2
-
-[node name="MenuButton" type="MenuButton" parent="Container/OptionsContainer/HBoxContainer"]
-layout_mode = 2
-icon = ExtResource("2_nerf3")
-flat = false
-clip_text = true
-item_count = 3
-popup/item_0/text = "Left"
-popup/item_0/icon = SubResource("CompressedTexture2D_q3rui")
-popup/item_1/text = "Right"
-popup/item_1/icon = SubResource("CompressedTexture2D_8crud")
-popup/item_1/id = 1
-popup/item_2/text = "Bottom"
-popup/item_2/icon = SubResource("CompressedTexture2D_8di4p")
-popup/item_2/id = 2
-
-[node name="PreviewContainer" type="ColorRect" parent="Container"]
-layout_mode = 2
-size_flags_vertical = 3
-mouse_default_cursor_shape = 6
-color = Color(0.301961, 0.301961, 0.301961, 1)
-
-[node name="TextureRect" type="TextureRect" parent="Container/PreviewContainer"]
-custom_minimum_size = Vector2(0, 2.08165e-12)
-layout_mode = 2
-offset_right = 640.0
-offset_bottom = 2158.0
-grow_horizontal = 2
-grow_vertical = 2
-texture = SubResource("ViewportTexture_ffsvy")
-stretch_mode = 6
-
-[node name="3D_Viewport" type="SubViewport" parent="Container/PreviewContainer"]
-transparent_bg = true
-
-[node name="Current_Viewport" type="SubViewport" parent="Container/PreviewContainer"]
-transparent_bg = true
-
-[node name="2D_Viewport" type="SubViewport" parent="Container/PreviewContainer"]
-transparent_bg = true
-size = Vector2i(640, 1726)
+[node name="Current_SubViewport" type="SubViewport" parent="."]
 render_target_update_mode = 4
 
-[connection signal="gui_input" from="Container/PreviewContainer" to="." method="_on_preview_container_gui_input"]
+[node name="SubViewport_2D" type="SubViewport" parent="."]
+size = Vector2i(1280, 720)
+render_target_update_mode = 4
+
+[node name="SubViewport_3D" type="SubViewport" parent="."]
+size = Vector2i(1280, 720)
+render_target_update_mode = 4

--- a/addons/Previewer_2D_3D/Previewer2D3D_OnOff.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D_OnOff.gd
@@ -1,22 +1,4 @@
 @tool
 extends Control
 
-var preview_instance
-
-var is_enabled = false
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	await get_tree().process_frame
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	if preview_instance:
-		preview_instance.visible = is_enabled
-	pass
-
-
-func _on_check_button_toggled(toggled_on):
-	is_enabled = toggled_on
-	pass # Replace with function body.
+@export var toggle_button : CheckButton

--- a/addons/Previewer_2D_3D/Previewer2D3D_OnOff.tscn
+++ b/addons/Previewer_2D_3D/Previewer2D3D_OnOff.tscn
@@ -2,29 +2,13 @@
 
 [ext_resource type="Script" path="res://addons/Previewer_2D_3D/Previewer2D3D_OnOff.gd" id="1_138vt"]
 
-[node name="Previewer2d3dOnOff" type="Control"]
-custom_minimum_size = Vector2(300, 2.08165e-12)
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_right = -1620.0
-offset_bottom = -1046.0
-grow_horizontal = 2
-grow_vertical = 2
+[node name="Previewer2d3dOnOff" type="HBoxContainer" node_paths=PackedStringArray("toggle_button")]
+offset_right = 143.0
+offset_bottom = 31.0
 script = ExtResource("1_138vt")
+toggle_button = NodePath("CheckButton")
 
 [node name="CheckButton" type="CheckButton" parent="."]
 custom_minimum_size = Vector2(100, 2.08165e-12)
-layout_mode = 1
-anchors_preset = 14
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -15.5
-offset_bottom = 15.5
-grow_horizontal = 2
-grow_vertical = 2
-text = "Previewer 2D/3D"
-
-[connection signal="toggled" from="CheckButton" to="." method="_on_check_button_toggled"]
+layout_mode = 2
+text = "2D | 3D"

--- a/addons/Previewer_2D_3D/Previewer2D3D_Plugin.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D_Plugin.gd
@@ -3,119 +3,81 @@ extends EditorPlugin
 
 #Load the preview scene
 const preview_scene = preload("res://addons/Previewer_2D_3D/Previewer2D3D.tscn")
-
 #Load the On Off button ( it allow the user to choose without the need of removing the plugin )
 const previewer_on_off = preload("res://addons/Previewer_2D_3D/Previewer2D3D_OnOff.tscn")
-
 #Current Editor actually open ( 2D/3D/Script/AssetLib/Tasks etc )
-var current_editor_view : String
-
+var current_editor_view : String = "2D"
 var preview_instance : Previewer2D3D
 var previewer_on_off_instance
-
 var position_menu_buttons
-
 #The position used for the preview ( in 3D view its called Spatial, since in 2D its called Canvas )
 var previewer_position_3D = EditorPlugin.CONTAINER_SPATIAL_EDITOR_SIDE_LEFT
-var previewer_position_2D = EditorPlugin.CONTAINER_CANVAS_EDITOR_SIDE_LEFT
+var previewer_position_2D = EditorPlugin.CONTAINER_CANVAS_EDITOR_SIDE_RIGHT
 
 func _enter_tree():
-	# Initialization of the plugin goes here.
-	#We connect the signal main_screen_changed to override it
-	main_screen_changed.connect(_on_main_screen_changed)
-	
-	preview_instance = preview_scene.instantiate()
+	#Initialization of the plugin goes here.
+	#Disable expansion of the 2D editor
+	#(NOTE: Seems to be required to keep SplitContainer size?) 
+	EditorInterface.get_editor_viewport_2d().get_parent().get_parent().size_flags_horizontal = Control.SIZE_FILL
+	#Instance the button and preview scenes
 	previewer_on_off_instance = previewer_on_off.instantiate()
-	#Passing the preview_instance to allow the on/off button to hide or show it ( Todo : use signal )
-	previewer_on_off_instance.preview_instance = preview_instance
-	
-
-func _ready() -> void:
-	#Godot dont contain method to refresh the actual view so we need to trick it with changing the view at the beginning
-	#If your read this sorry for the stress of seeing your godot clipping at start with the plugin
-	EditorInterface.set_main_screen_editor("Script")
+	preview_instance = preview_scene.instantiate()
+	#Connect signals
+	main_screen_changed.connect(_on_main_screen_changed)
+	previewer_on_off_instance.toggle_button.toggled.connect(_toggled)
+	preview_instance.gui_input.connect(_preview_window_gui_input)
+	#Set the initial state
+	#(NOTE: Swapping views forces the button to be instanced)
+	EditorInterface.set_main_screen_editor("3D")
 	EditorInterface.set_main_screen_editor("2D")
-	
-	#To connect the preview_instance signal we need to wait it to be ready blocking for few second dont hurt
-	await preview_instance.get_tree().process_frame
-	
-	#Connect the Dock Position Menu buttons to the plugin script, since we can only change its position from here
-	position_menu_buttons = preview_instance.positionMenuButtons.get_popup().id_pressed.connect(_on_position_changed)
-	pass
-
-#If we ask for docked position changed
-func _on_position_changed(id):
-	#Store the old position
-	var old_previewer_position_2D = previewer_position_2D
-	var old_previewer_position_3D = previewer_position_3D
-	
-	#Change the position for 2D and 3D views
-	match id:
-		0:
-			previewer_position_3D = CONTAINER_SPATIAL_EDITOR_SIDE_LEFT
-			previewer_position_2D = CONTAINER_CANVAS_EDITOR_SIDE_LEFT
-		1: 
-			previewer_position_3D = CONTAINER_SPATIAL_EDITOR_SIDE_RIGHT
-			previewer_position_2D = CONTAINER_CANVAS_EDITOR_SIDE_RIGHT
-		2:
-			previewer_position_3D = CONTAINER_SPATIAL_EDITOR_BOTTOM
-			previewer_position_2D = CONTAINER_CANVAS_EDITOR_BOTTOM
-
-	
-	if(current_editor_view == "2D"):
-		_change_preview_position_in_2D(old_previewer_position_2D)
-	if(current_editor_view == "3D"):
-		_change_preview_position_in_3D(old_previewer_position_3D)
-			
-func _on_main_screen_changed(screen_name: String) -> void:
-	#Since Godot manage 2D and 3D view separatly
-	#and it consider that since we add a control to a view we cannot set it to another
-	#we need for each change to delete the used in the previous to add it in the new
-	#Example : We are in 2D view with the 3D preview 
-	#If we switch to 3D view we delete the plugin view from the 2D view and read it to the 3D view
-	#And request the preview to show now the 2D preview
-	
-	#Note : we also had to do it for the On/Off Button, the topbar ( toolbar ) is also not shared between views
-	
-	current_editor_view = screen_name
-	
-	if(current_editor_view == "2D"):
-		preview_instance.set_3D_preview_mode()
-		_set_preview_in_2D()
-		_set_on_off_button_in_2D()
-		
-	if(current_editor_view == "3D"):
-		preview_instance.set_2D_preview_mode()
-		_set_preview_in_3D()
-		_set_on_off_button_in_3D()
-		
-func _set_preview_in_2D():
-	remove_control_from_container(previewer_position_3D, preview_instance)
-	add_control_to_container(previewer_position_2D, preview_instance)
-	
-func _set_preview_in_3D():
-	remove_control_from_container(previewer_position_2D, preview_instance)
-	add_control_to_container(previewer_position_3D, preview_instance)
-
-func _change_preview_position_in_2D(old_previewer_position_2D):
-	remove_control_from_container(old_previewer_position_2D, preview_instance)
-	add_control_to_container(previewer_position_2D, preview_instance)
-		
-func _change_preview_position_in_3D(old_previewer_position_3D):
-	remove_control_from_container(old_previewer_position_3D, preview_instance)
-	add_control_to_container(previewer_position_3D, preview_instance)
-	
-func _set_on_off_button_in_2D():
-	remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, previewer_on_off_instance)
-	add_control_to_container(EditorPlugin.CONTAINER_CANVAS_EDITOR_MENU, previewer_on_off_instance)
-
-func _set_on_off_button_in_3D():
-	remove_control_from_container(EditorPlugin.CONTAINER_CANVAS_EDITOR_MENU, previewer_on_off_instance)
-	add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, previewer_on_off_instance)
-
+	preview_instance.visible = false
 
 func _exit_tree():
 	#Clean plugin if removed
 	preview_instance.queue_free()
 	previewer_on_off_instance.queue_free()
-	pass
+
+# ----- CONNECTED BY SIGNALS ----- #
+
+func _toggled(toggled_on : bool):
+	preview_instance.visible = toggled_on
+	if toggled_on:
+		var editor_size : Vector2 = (preview_instance.get_parent_control().size)
+		var preview_size : Vector2 = Vector2((editor_size.x / 2), editor_size.y)
+		preview_instance.get_parent().split_offset = preview_size.x
+		match current_editor_view:
+			"2D":
+				preview_instance.switch_preview(Previewer2D3D_Enums.PreviewMode.PREVIEW_3D, preview_size)
+			"3D":
+				preview_instance.switch_preview(Previewer2D3D_Enums.PreviewMode.PREVIEW_2D, preview_size)
+
+func _on_main_screen_changed(screen_name : String):
+	match screen_name:
+		"2D":
+			#Switching from to native 2D view (faux 3D preview pane)...
+			remove_control_from_container(previewer_position_3D, preview_instance)
+			add_control_to_container(previewer_position_2D, preview_instance)
+			remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, previewer_on_off_instance)
+			add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, previewer_on_off_instance)
+			var preview_size : Vector2 = EditorInterface.get_editor_viewport_3d().size
+			#print(preview_size)
+			preview_instance.switch_preview(Previewer2D3D_Enums.PreviewMode.PREVIEW_3D, preview_size)
+		"3D":
+			#Switching from to native 3D view (faux 2D preview pane)...
+			remove_control_from_container(previewer_position_2D, preview_instance)
+			add_control_to_container(previewer_position_3D, preview_instance)
+			remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, previewer_on_off_instance)
+			add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, previewer_on_off_instance)
+			var preview_size : Vector2 = EditorInterface.get_editor_viewport_2d().size
+			#print(preview_size)
+			preview_instance.switch_preview(Previewer2D3D_Enums.PreviewMode.PREVIEW_2D, preview_size)
+	#Update variable
+	current_editor_view = screen_name
+
+func _preview_window_gui_input(input_event : InputEvent) -> void:
+	#If mouse entered the preview window... swap to the opposite mode in the editor
+	match current_editor_view:
+		"2D":
+			EditorInterface.set_main_screen_editor("3D")
+		"3D":
+			EditorInterface.set_main_screen_editor("2D")

--- a/addons/Previewer_2D_3D/Previewer2D3D_Plugin.gd
+++ b/addons/Previewer_2D_3D/Previewer2D3D_Plugin.gd
@@ -60,7 +60,6 @@ func _on_main_screen_changed(screen_name : String):
 			remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, previewer_on_off_instance)
 			add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, previewer_on_off_instance)
 			var preview_size : Vector2 = EditorInterface.get_editor_viewport_3d().size
-			#print(preview_size)
 			preview_instance.switch_preview(Previewer2D3D_Enums.PreviewMode.PREVIEW_3D, preview_size)
 		"3D":
 			#Switching from to native 3D view (faux 2D preview pane)...
@@ -69,7 +68,6 @@ func _on_main_screen_changed(screen_name : String):
 			remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, previewer_on_off_instance)
 			add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, previewer_on_off_instance)
 			var preview_size : Vector2 = EditorInterface.get_editor_viewport_2d().size
-			#print(preview_size)
 			preview_instance.switch_preview(Previewer2D3D_Enums.PreviewMode.PREVIEW_2D, preview_size)
 	#Update variable
 	current_editor_view = screen_name


### PR DESCRIPTION
Sorry for the delay - I've managed to get the PR to a point that I'm happy with, but please test it to make sure there are no bugs! It changes the functionality of the plugin quite a bit, so please keep that in mind.

**Changes**
- Hovering over the preview pane now swaps between Godot's native 2D/3D editors
- Swapping between 2D and 3D editors _should_ appear seamless, by keeping both panes at the same size & in the same position

**Missing features**
- Custom docking positions are yet to be added
- 2D/Canvas grid doesn't appear during preview mode (wasn't sure how to implement this)